### PR TITLE
Update schema & profile resolver

### DIFF
--- a/src/api/User/profile/profile.js
+++ b/src/api/User/profile/profile.js
@@ -3,10 +3,12 @@ module.exports = {
     profile: async (parent, args, ctx) => {
       const userExists = await ctx.prisma.user.findUnique({
         where: { handle: args.handle },
-        include: { 
+        include: {
           tweets: {
             include: {
               user: true,
+              files: true,
+              reactions: true,
             },
             orderBy: {
               createdAt: "desc",
@@ -16,8 +18,6 @@ module.exports = {
           following: true,
           followers: true,
           comments: true,
-          reactions: true,
-          files: true
         }
       });
 

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -16,8 +16,8 @@ type User {
   following: [User!]!
   followers: [User!]!
   comments: [Comment!]!
-  reactions: [Reaction!]
-  files: [File!]
+  reactions: [Reaction!]!
+  files: [File!]!
   # computed fields
   isSelf: Boolean!
   isFollowing: Boolean!
@@ -35,10 +35,10 @@ type Tweet {
   user: User
   text: String!
   tags: [String!]!
-  files: [File!]
+  files: [File!]!
   mentions: [String!]
   comments: [Comment!]!
-  reactions: [Reaction!]
+  reactions: [Reaction!]!
   retweets: [Retweet!]!
   # computer fields
   commentsCount: Int!


### PR DESCRIPTION
- Make sure `files` and `reactions` return an empty array instead of `null`.

I think this was the reason for why files/images weren't loading occasionally. It was doing a double call where the first call had `files` but then the next call had `files` as `null`.

Needs to be merged in together with this [pr](https://github.com/sosol-gmi/sosol-client/pull/48)